### PR TITLE
Add line info

### DIFF
--- a/packages/orga/src/parser.js
+++ b/packages/orga/src/parser.js
@@ -34,7 +34,9 @@ Parser.prototype.getToken = function(index) {
   if (index >= self.tokens.length) {
     const start = self.tokens.length
     for (var i = start; i <= index; i++) {
-      self.tokens.push(self.lexer.tokenize(self.lines[i]))
+      const token = self.lexer.tokenize(self.lines[i])
+      token.line = i
+      self.tokens.push(token)
     }
   }
   return self.tokens[index]

--- a/packages/orga/src/processors/headline.js
+++ b/packages/orga/src/processors/headline.js
@@ -23,13 +23,13 @@ function parseDrawer() {
 
 function process(token, section) {
   if (section.type === `footnote.definition`) return section // headline breaks footnote
-  const { level, keyword, priority, tags, content } = token.data
+  const { data: { level, keyword, priority, tags, content }, line } = token
   const currentLevel = section.level || 0
   if (level <= currentLevel) { return section }
   this.consume()
   const text = inlineParse(content)
   var headline = new Node('headline', text).with({
-    level, keyword, priority, tags
+    level, keyword, priority, tags, line
   })
   const planning = this.tryTo(parsePlanning)
   if (planning) {

--- a/packages/orga/src/processors/list.js
+++ b/packages/orga/src/processors/list.js
@@ -6,9 +6,9 @@ function process(token, section) {
   var self = this
 
   const parseListItem = () => {
-    const { indent, content, ordered, checked } = self.next().data
+    const { data: { indent, content, ordered, checked }, line } = self.next()
     var lines = [content]
-    const item = new Node(`list.item`).with({ ordered })
+    const item = new Node(`list.item`).with({ ordered, line })
     if (checked !== undefined) {
       item.checked = checked
     }
@@ -24,7 +24,7 @@ function process(token, section) {
   }
 
   const parseList = level => {
-    const list = new Node(`list`)
+    const list = new Node(`list`).with({ line: token.line })
     while (self.hasNext()) {
       const token = self.peek()
       if ( token.name != `list.item` ) break


### PR DESCRIPTION
Hi, I am trying to use orga for a project and I need line numbers for parsed tokens. I actually need only `headline` and `list`, so I implemented it only for these as a proof of concept. I think line info for other tokens could be added in a similar fashion if this solution becomes acceptable.

In https://github.com/xiaoxinghu/orgajs/issues/3 there is a mention of a potential performance penalty. Maybe I am missing something but I don't see a potential performance penalty since the parser already works by splitting input to lines.