### PR TITLE
Add XRegExp library to support Timestamp regexp in Firefox

### DIFF
--- a/packages/orga/src/lexer.ts
+++ b/packages/orga/src/lexer.ts
@@ -1,6 +1,7 @@
 import defaultOptions, { ParseOptions } from './options'
 import { escape } from './utils'
 import { parse as parseTimestamp, pattern as timestampPattern } from './timestamp'
+const XRegExp = require('xregexp');
 
 type Rule = {
   name: string
@@ -63,7 +64,7 @@ org.define('planning', RegExp(`^\\s*(${PLANNING_KEYWORDS.join('|')}):\\s*(.+)$`)
   return { keyword, ...parseTimestamp(m[2], options) }
 })
 
-org.define('timestamp', RegExp(timestampPattern, 'i'), (m, options) => {
+org.define('timestamp', XRegExp(timestampPattern, 'i'), (m, options) => {
   // console.log(options)
   return parseTimestamp(m, options)
 })

--- a/packages/orga/src/timestamp.ts
+++ b/packages/orga/src/timestamp.ts
@@ -1,4 +1,5 @@
 const { DateTime } = require('luxon')
+const XRegExp = require('xregexp');
 
 namespace Timestamp {
   const date = `\\d{4}-\\d{2}-\\d{2}`
@@ -31,14 +32,16 @@ export const parse = (
 ) => {
   let m = input
   if (typeof input === 'string') {
-    m = RegExp(Timestamp.full, 'i').exec(m)
+    m = XRegExp(Timestamp.full, 'i').exec(m)
   }
   if (!m) return null
 
-  const {
-    beginDate, beginTimeBegin, beginTimeEnd,
-    endDate, endTimeBegin
-  } = m.groups
+  const beginDate = m[2];
+  const beginTimeBegin = m[3];
+  const beginTimeEnd = m[4];
+  const endDate = m[5];
+  const endTimeBegin = m[6];
+  const endTimeEnd = m[7];
 
   const _parseDate = (date, time) => {
     let text = date

--- a/yarn.lock
+++ b/yarn.lock
@@ -1127,6 +1127,14 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime-corejs3@^7.8.3":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz#ccc4e042e2fae419c67fa709567e5d2179ed3940"
+  integrity sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.2.0.tgz#b03e42eeddf5898e00646e4c840fa07ba8dcad7f"
@@ -5637,6 +5645,11 @@ core-js-compat@^3.1.1:
   dependencies:
     browserslist "^4.6.6"
     semver "^6.3.0"
+
+core-js-pure@^3.0.0:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
+  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -18007,6 +18020,13 @@ xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
   integrity sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=
+
+xregexp@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.3.0.tgz#7e92e73d9174a99a59743f67a4ce879a04b5ae50"
+  integrity sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==
+  dependencies:
+    "@babel/runtime-corejs3" "^7.8.3"
 
 xstate@^4.6.7:
   version "4.6.7"


### PR DESCRIPTION
As of now, Firefox does not yet support named capture groups
in RegExp objects. This is used in timestamp.ts where the
Timestamp.full pattern is currently built into

```javascript
^\s*([<\[](?<beginDate>\d{4}-\d{2}-\d{2})\s+[a-zA-Z]+(?:\s+(?<beginTimeBegin>\d{2}:\d{2})(?:-(?<beginTimeEnd>\d{2}:\d{2}))?)?[>\]])(?:--[<\[](?<endDate>\d{4}-\d{2}-\d{2})\s+[a-zA-Z]+(?:\s+(?<endTimeBegin>\d{2}:\d{2})(?:-(?<endTimeEnd>\d{2}:\d{2}))?)?[>\]])?\s*$
```

the XRegExp library provides cross-browser named capture groups
support but returns capture groups as an array. This commit
applies XRegExp for use only for the Timestamp patterns, and
unpacks the match groups by explicit array indexing.

In the www playground element in Firefox, this commit:
1. enables loading of the playground
2. successfully parses a full org-mode timestamp string, e.g.

```org
** Meeting in Amsterdam
   <2004-08-23 Mon 01:23-16:45>--<2006-11-02 Thu 20:00-22:00>
```