### PR TITLE
metadata now found in pathContext

### DIFF
--- a/www/src/gatsby-theme-orga/components/post.js
+++ b/www/src/gatsby-theme-orga/components/post.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Layout from '../../components/layout'
 
-export default ({ body, metadata }) => {
+export default ({ body, pathContext: metadata }) => {
   const { title } = metadata
   return (
     <Layout>


### PR DESCRIPTION
The demo page wasn't building because metadata has moved into pathContext.  This change fixes that.