### PR TITLE
Peer dependency has gotten stale

### DIFF
--- a/packages/gatsby-theme-blorg/package.json
+++ b/packages/gatsby-theme-blorg/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.6.0"
+    "gatsby": "^2.x"
   },
   "dependencies": {
     "@emotion/core": "^10.0.22",


### PR DESCRIPTION
This fixes lots of warnings when running yarn install.