### PR TITLE
Stop using pathContext

### DIFF
--- a/packages/gatsby-theme-orga/src/templates/post-query.js
+++ b/packages/gatsby-theme-orga/src/templates/post-query.js
@@ -1,13 +1,15 @@
 import { graphql } from 'gatsby'
 import PostPage from '../components/post'
 
-const mapProps = Component => ({ data, pageContext: { metadata }, ...props }) =>
-      Component({
-        ...metadata,
-        body: data.orgContent.html,
-        slug: data.orgContent.fields.slug,
-        ...props,
-      })
+const mapProps = Component => ({ data, ...props }) => {
+  var {pageContext: { metadata }} = props;
+  return Component({
+    ...metadata,
+    body: data.orgContent.html,
+    slug: data.orgContent.fields.slug,
+    ...props,
+  })
+}
 
 export default mapProps(PostPage)
 

--- a/packages/orga/src/timestamp.ts
+++ b/packages/orga/src/timestamp.ts
@@ -41,7 +41,6 @@ export const parse = (
   const beginTimeEnd = m[4];
   const endDate = m[5];
   const endTimeBegin = m[6];
-  const endTimeEnd = m[7];
 
   const _parseDate = (date, time) => {
     let text = date

--- a/www/src/gatsby-theme-orga/components/post.js
+++ b/www/src/gatsby-theme-orga/components/post.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Layout from '../../components/layout'
 
-export default ({ body, pathContext: metadata }) => {
+export default ({ body, pageContext: metadata }) => {
   const { title } = metadata
   return (
     <Layout>


### PR DESCRIPTION
In Gatsby pathContext has been [renamed to pageContext](https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-pathcontext-to-pagecontext).  Stop using the deprecated old name.

FWIW, it took me a while to figure out where it was being removed from props.

I also removed an unused endTimeEnd variable which was generating warnings with `yarn run develop`.