### PR TITLE
Allow multiple planning items

### DIFF
--- a/packages/orga/src/processors/headline.ts
+++ b/packages/orga/src/processors/headline.ts
@@ -37,9 +37,10 @@ function process(token, section) {
   const headline = new Node('headline', text).with({
     level, keyword, priority, tags
   })
-  const planning = this.tryTo(parsePlanning)
-  if (planning) {
+  var planning = this.tryTo(parsePlanning)
+  while (planning) {
     headline.push(planning)
+    planning = this.tryTo(parsePlanning)
   }
   const timestamp = this.tryTo(parseTimestamp)
   if (timestamp) {

--- a/packages/orga/src/timestamp.ts
+++ b/packages/orga/src/timestamp.ts
@@ -20,7 +20,6 @@ ${close}\
   export const full = `^\\s*\
 (${single('begin')})\
 (?:--${single('end')})?\
-\\s*$\
 `
 }
 


### PR DESCRIPTION
Partial fix for #55.  Full fix requires allowing multiple tokens to exist on a single line.