### PR TITLE
Use a NodeType enum instead of string

### DIFF
--- a/packages/orga/src/index.ts
+++ b/packages/orga/src/index.ts
@@ -1,4 +1,5 @@
 import Parser from './parser'
+import Node, { NodeType } from './node'
 import { parse as parseTimestamp } from './timestamp'
 
 import defaultOptions from './options'
@@ -10,3 +11,4 @@ export const parse = (string: string, options = defaultOptions) => {
 
 export { Parser }
 export { parseTimestamp }
+export { Node, NodeType }

--- a/packages/orga/src/node.ts
+++ b/packages/orga/src/node.ts
@@ -1,9 +1,38 @@
+export enum NodeType {
+  Link = 'link',
+  FootnoteReference = 'footnote.reference',
+  Text = 'text',
+  Root = 'root',
+  Block = 'block',
+  FootnoteDefinition = 'footnote.definition',
+  Planning = 'planning',
+  Drawer = 'drawer',
+  Timestamp = 'timestamp',
+  Headline = 'headline',
+  Section = 'section',
+  HorizontalRule = 'horizontalRule',
+  Html = 'html',
+  Paragraph = 'paragraph',
+  Table = 'table',
+  TableSeparator = 'table.separator',
+  TableRow = 'table.row',
+  TableCell = 'table.cell',
+  Bold = 'bold',
+  Verbatim = 'verbatim',
+  Italic = 'italic',
+  StrikeThrough = 'strikeThrough',
+  Underline = 'underline',
+  Code = 'code',
+  List = 'list',
+  ListItem = 'list.item',
+}
+
 export default class Node {
-  type: string
+  type: NodeType
   children: Node[]
   parent?: Node
 
-  constructor(type: string, children = []) {
+  constructor(type: NodeType, children = []) {
     this.type = type
     this.children = []
     this.push(children)
@@ -13,7 +42,7 @@ export default class Node {
   push(node: Node): void
   push(node: string): void
 
-  push(node: any): void {
+  push(node: Node[] | Node | string): void {
     if (Array.isArray(node)) {
       for (const n of node) {
         this.push(n)
@@ -22,7 +51,7 @@ export default class Node {
       node.parent = this
       this.children.push(node)
     } else if (typeof node === `string`) {
-      const newNode = new Node(`text`).with({ value: node })
+      const newNode = new Node(NodeType.Text).with({ value: node })
       newNode.parent = this
       this.children.push(newNode)
     }

--- a/packages/orga/src/parser.ts
+++ b/packages/orga/src/parser.ts
@@ -1,7 +1,7 @@
 import defaultOptions, { ParseOptions } from './options'
 
 import Lexer from './lexer'
-import Node from './node'
+import Node, { NodeType } from './node'
 
 declare namespace orga {
 
@@ -33,7 +33,7 @@ class OrgaParser implements orga.Parser {
 
   parse(text: string): Node {
     const self = this
-    const document = new Node('root').with({ meta: {} })
+    const document = new Node(NodeType.Root).with({ meta: {} })
     self.cursor = -1
     self.lines = text.split('\n') // TODO: more robust lines?
       self.tokens = []

--- a/packages/orga/src/processors/block.ts
+++ b/packages/orga/src/processors/block.ts
@@ -1,4 +1,4 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 
 function parseBlock() {
   const t = this.next()
@@ -12,7 +12,7 @@ function parseBlock() {
         const format = params[0]
         return new Node(format).with({ value: lines.join(`\n`) })
       }
-      return new Node('block').with({ name: type.toUpperCase(), params, value: lines.join(`\n`) })
+      return new Node(NodeType.Block).with({ name: type.toUpperCase(), params, value: lines.join(`\n`) })
     }
     lines.push(t.raw)
   }

--- a/packages/orga/src/processors/footnote.ts
+++ b/packages/orga/src/processors/footnote.ts
@@ -1,4 +1,4 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 
 function process(token, section) {
 
@@ -8,7 +8,7 @@ function process(token, section) {
   const parseFootnote = () => {
     const { label, content } = self.next().data
     self.prefix = [{ name: `line`, raw: content, data: { content: content.trim() } }]
-    return self.parseSection(new Node(`footnote.definition`).with({ label }))
+    return self.parseSection(new Node(NodeType.FootnoteDefinition).with({ label }))
   }
   section.push(parseFootnote())
   self._aks = {}

--- a/packages/orga/src/processors/headline.ts
+++ b/packages/orga/src/processors/headline.ts
@@ -1,10 +1,10 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 const inlineParse = require('../inline').parse
 
 function parsePlanning() {
   const token = this.next()
   if (!token || token.name !== `planning`) { return undefined }
-  return new Node('planning').with(token.data)
+  return new Node(NodeType.Planning).with(token.data)
 }
 
 function parseDrawer() {
@@ -14,7 +14,7 @@ function parseDrawer() {
     const t = this.next()
     if ( t.name === `headline` ) { return undefined }
     if (t.name === `drawer.end` ) {
-      return new Node('drawer').with({ name: begin.data.type, value: lines.join(`\n`) })
+      return new Node(NodeType.Drawer).with({ name: begin.data.type, value: lines.join(`\n`) })
     }
     lines.push(t.raw)
   }
@@ -24,7 +24,7 @@ function parseDrawer() {
 function parseTimestamp() {
   const token = this.next()
   if (!token || token.name !== `timestamp`) { return undefined }
-  return new Node('timestamp').with(token.data)
+  return new Node(NodeType.Timestamp).with(token.data)
 }
 
 function process(token, section) {
@@ -34,7 +34,7 @@ function process(token, section) {
   if (level <= currentLevel) { return section }
   this.consume()
   const text = inlineParse(content)
-  const headline = new Node('headline', text).with({
+  const headline = new Node(NodeType.Headline, text).with({
     level, keyword, priority, tags
   })
   const planning = this.tryTo(parsePlanning)
@@ -54,7 +54,7 @@ function process(token, section) {
     }
     headline.push(drawer)
   }
-  const newSection = new Node(`section`).with({ level })
+  const newSection = new Node(NodeType.Section).with({ level })
   newSection.push(headline)
   section.push(this.parseSection(this.unagi(newSection)))
   this._aks = {}

--- a/packages/orga/src/processors/horizontal-rule.ts
+++ b/packages/orga/src/processors/horizontal-rule.ts
@@ -1,8 +1,8 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 
 function process(token, section) {
   this.consume()
-  section.push(new Node(`horizontalRule`))
+  section.push(new Node(NodeType.HorizontalRule))
   this._aks = {}
   return this.parseSection(section)
 }

--- a/packages/orga/src/processors/keyword.ts
+++ b/packages/orga/src/processors/keyword.ts
@@ -1,4 +1,4 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 
 function process(token, section) {
   const { key, value } = token.data
@@ -13,7 +13,7 @@ function process(token, section) {
     this.lexer.updateTODOs(section.meta.todos)
     break
   case `HTML`:
-    section.push(new Node(`html`).with({ value }))
+    section.push(new Node(NodeType.Html).with({ value }))
     break
   case `CAPTION`:
   case `HEADER`:

--- a/packages/orga/src/processors/line.ts
+++ b/packages/orga/src/processors/line.ts
@@ -1,4 +1,4 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 const inlineParse = require('../inline').parse
 
 function process(token, section) {
@@ -11,7 +11,7 @@ function process(token, section) {
     this.consume()
     push(token.raw.trim())
   }
-  section.push(new Node(`paragraph`, nodes))
+  section.push(new Node(NodeType.Paragraph, nodes))
 
   this._aks = {}
   return this.parseSection(section)

--- a/packages/orga/src/processors/list.ts
+++ b/packages/orga/src/processors/list.ts
@@ -1,4 +1,4 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 const inlineParse = require('../inline').parse
 
 class List extends Node {
@@ -19,7 +19,7 @@ export default function(token, section: Node): Node {
   const parseListItem = () => {
     const { indent, content, ordered, checked, tag } = self.next().data
     const lines = [content]
-    const item = new ListItem(`list.item`).with({ ordered, tag })
+    const item = new ListItem(NodeType.ListItem).with({ ordered, tag })
     if (checked !== undefined) {
       item.checked = checked
     }
@@ -35,7 +35,7 @@ export default function(token, section: Node): Node {
   }
 
   const parseList = level => {
-    const list = new List(`list`)
+    const list = new List(NodeType.List)
     while (self.hasNext()) {
       const token = self.peek()
       if ( token.name !== `list.item` ) break

--- a/packages/orga/src/processors/table.ts
+++ b/packages/orga/src/processors/table.ts
@@ -1,4 +1,4 @@
-import Node from '../node'
+import Node, { NodeType } from '../node'
 const inlineParse = require('../inline').parse
 
 function process(token, section) {
@@ -6,18 +6,18 @@ function process(token, section) {
   const self = this
 
   const parseTable = () => {
-    const table = new Node(`table`)
+    const table = new Node(NodeType.Table)
     while (self.hasNext()) {
       const token = self.peek()
       if ( !token.name.startsWith(`table.`) ) break
       self.consume()
       if (token.name === `table.separator`) {
-        table.push(new Node(`table.separator`))
+        table.push(new Node(NodeType.TableSeparator))
         continue
       }
       if ( token.name !== `table.row` ) break
-      const cells = token.data.cells.map(c => new Node(`table.cell`, inlineParse(c)))
-      const row = new Node(`table.row`, cells)
+      const cells = token.data.cells.map(c => new Node(NodeType.TableCell, inlineParse(c)))
+      const row = new Node(NodeType.TableRow, cells)
       table.push(row)
     }
     return table


### PR DESCRIPTION
It would be great to see what all the node types are in the editor itself, rather than comparing `type` against strings, which are error-prone.

This PR introduces a NodeType enum so all the types can be statically checked.

I went over the diff, and there aren't any typos, but I would like a second look :sweat_smile: 