### PR TITLE
Fix property matching ":" in value

### DIFF
--- a/packages/orga/src/parse/section.ts
+++ b/packages/orga/src/parse/section.ts
@@ -39,7 +39,7 @@ export default (lexer: Lexer) => <T extends Document | Section>(root: T): T => {
     while (tryTo(parseDrawer)(drawer => {
       if (drawer.name.toLowerCase() === 'properties') {
         section.properties = drawer.value.split('\n').reduce((accu, current) => {
-          const m = current.match(/\s*:(.+):\s*(.+)\s*$/)
+          const m = current.match(/\s*:(.+?):\s*(.+)\s*$/)
           if (m) {
             return { ...accu, [m[1].toLowerCase()]: m[2] }
           }


### PR DESCRIPTION
Related issue case:
https://orga.js.org?text=*%20Foo%0A%3APROPERTIES%3A%0A%3AURL%3A%20%20%20%20%20%20https%3A%2F%2Fblog.shanock.com%2Frooting-a-nook%2F%0A%3AEXTENSION_FOO%3A%20%20%20%20%20%20This%20is%20what%20%3A%22%20this%20looks%20like%0A%3AHELLOW%3A%20sdfsf%3A%20sdfsdf%20immager%0A%3AEND%3A

When matching properties with a colon in the value, the key matcher would be to greedy.

So a property like this

```org
:PROPERTIES:
:KEY: https://abc.xyz
:END:
```

Would end up with a key `key: https:`.

I could not get the tests to fail and running the snapshot update script did not work,
so I'm not 100% sure if this was the causing issue (it would be great to enhance the documentation for contribution).