### PR TITLE
Fix unclosed property drawers causing a crash

### DIFF
--- a/packages/orga/src/parse/drawer.ts
+++ b/packages/orga/src/parse/drawer.ts
@@ -17,7 +17,11 @@ export default (lexer: Lexer): Drawer | undefined => {
     value: '' }
   eat()
 
-  const contentPosition: Position = peek().position
+  const content = peek();
+  if (content === undefined) {
+    return undefined;
+  }
+  const contentPosition: Position = content.position;
 
   const parse = (): Drawer | undefined => {
     const n = peek()

--- a/packages/orga/src/parse/section.ts
+++ b/packages/orga/src/parse/section.ts
@@ -21,7 +21,7 @@ const attach = (attributes: Attributes) => (node: Attributed) => {
 
 export default (lexer: Lexer) => <T extends Document | Section>(root: T): T => {
 
-  const { peek, eat, eatAll } = lexer
+  const { peek, eat, eatAll, modify } = lexer
   const { tryTo } = utils(lexer)
 
   const newSection = (props: { [key: string]: string } = {}): Section => {
@@ -48,6 +48,12 @@ export default (lexer: Lexer) => <T extends Document | Section>(root: T): T => {
       }
       push(section)(drawer)
     })) continue
+
+    const token = peek();
+    if (token && token.type === 'drawer.begin' && token.name.toLowerCase() === 'properties') {
+      // we encountered an unclosed property drawer, so this should just be treated as text
+      modify(t => ({ ...t, type: 'text.plain', value: `:${token.name}:` }));
+    }
     return section
   }
 

--- a/packages/orga/src/tokenize/index.ts
+++ b/packages/orga/src/tokenize/index.ts
@@ -25,9 +25,11 @@ export interface Lexer {
   restore: (point: number) => void;
   addInBufferTodoKeywords: (text: string) => void;
   substring: (position: Position) => string;
+  /** Modify the next token (or the token at the given offset). */
+  modify(f: (t: Token) => Token, offset?: number): void;
 }
 
-export const tokenize = (text: string, options: Partial<ParseOptions> = {}) => {
+export const tokenize = (text: string, options: Partial<ParseOptions> = {}): Lexer => {
 
   const { timezone, todos } = { ...defaultOptions, ...options }
 
@@ -145,7 +147,15 @@ export const tokenize = (text: string, options: Partial<ParseOptions> = {}) => {
     return tokens[pos]
   }
 
-  const _eat = (type: string | undefined = undefined) : Token | undefined => {
+  const modify = (f: (t: Token) => Token, offset = 0): void => {
+    const pos = cursor + offset
+    const token = peek(offset);
+    if (token !== undefined) {
+      tokens[pos] = f(token);
+    }
+  }
+
+  const _eat = (type: string | undefined = undefined): Token | undefined => {
     const t = peek()
     if (!t) return undefined
     if (!type || type === t.type) {
@@ -190,6 +200,6 @@ export const tokenize = (text: string, options: Partial<ParseOptions> = {}) => {
       inBufferTodoKeywordSets.push(todoKeywordSet(text))
     },
     substring,
-
-  } as Lexer
+    modify
+  };
 }


### PR DESCRIPTION
Fixes #98.

@xiaoxinghu When a property drawer is unclosed, this just treats it as text.

I've added the `modify` method for `Lexer`, which allows you to modify a token in the lexer in-place. So in this case, if we see a property drawer token after trying to parse a property drawer, then we know it is unclosed and can modify it to be text.

A probably better approach for the future is to have the lexer check ahead for a drawer close, and only treat `:PROPERTIES:` as a `drawer.begin` token if there is a close for the drawer.

Edit: actually I think this should _technically_ be handled in the parser (as it is in this PR), because the lexer shouldn't really be able to deal with nesting. It's probably okay to mix and match the lexer and parser a bit though, as long as they work properly.