### PR TITLE
Text-Kit Tweaks

### DIFF
--- a/packages/orga/src/parse/__tests__/__snapshots__/paragraph.spec.ts.snap
+++ b/packages/orga/src/parse/__tests__/__snapshots__/paragraph.spec.ts.snap
@@ -17,10 +17,12 @@ Object {
             "end": Object {
               "column": 49,
               "line": 3,
+              "offset": 88,
             },
             "start": Object {
               "column": 1,
               "line": 3,
+              "offset": 40,
             },
           },
           "protocol": "https",
@@ -34,10 +36,12 @@ Object {
             "end": Object {
               "column": 57,
               "line": 3,
+              "offset": 96,
             },
             "start": Object {
               "column": 49,
               "line": 3,
+              "offset": 88,
             },
           },
           "type": "text.plain",
@@ -49,10 +53,12 @@ Object {
             "end": Object {
               "column": 64,
               "line": 3,
+              "offset": 103,
             },
             "start": Object {
               "column": 57,
               "line": 3,
+              "offset": 96,
             },
           },
           "type": "text.bold",
@@ -64,10 +70,12 @@ Object {
             "end": Object {
               "column": 75,
               "line": 3,
+              "offset": 114,
             },
             "start": Object {
               "column": 64,
               "line": 3,
+              "offset": 103,
             },
           },
           "type": "text.plain",
@@ -79,10 +87,12 @@ Object {
             "end": Object {
               "column": 84,
               "line": 3,
+              "offset": 123,
             },
             "start": Object {
               "column": 75,
               "line": 3,
+              "offset": 114,
             },
           },
           "type": "text.italic",
@@ -94,10 +104,12 @@ Object {
             "end": Object {
               "column": 90,
               "line": 3,
+              "offset": 129,
             },
             "start": Object {
               "column": 84,
               "line": 3,
+              "offset": 123,
             },
           },
           "type": "text.plain",
@@ -109,10 +121,12 @@ Object {
             "end": Object {
               "column": 98,
               "line": 3,
+              "offset": 137,
             },
             "start": Object {
               "column": 90,
               "line": 3,
+              "offset": 129,
             },
           },
           "type": "text.underline",
@@ -124,10 +138,12 @@ Object {
             "end": Object {
               "column": 104,
               "line": 3,
+              "offset": 143,
             },
             "start": Object {
               "column": 98,
               "line": 3,
+              "offset": 137,
             },
           },
           "type": "text.plain",
@@ -139,10 +155,12 @@ Object {
             "end": Object {
               "column": 119,
               "line": 3,
+              "offset": 158,
             },
             "start": Object {
               "column": 104,
               "line": 3,
+              "offset": 143,
             },
           },
           "type": "text.code",
@@ -154,10 +172,12 @@ Object {
             "end": Object {
               "column": 120,
               "line": 3,
+              "offset": 159,
             },
             "start": Object {
               "column": 119,
               "line": 3,
+              "offset": 158,
             },
           },
           "type": "text.plain",
@@ -169,10 +189,12 @@ Object {
             "end": Object {
               "column": 1,
               "line": 4,
+              "offset": 160,
             },
             "start": Object {
               "column": 120,
               "line": 3,
+              "offset": 159,
             },
           },
           "type": "text.plain",
@@ -184,10 +206,12 @@ Object {
             "end": Object {
               "column": 23,
               "line": 4,
+              "offset": 182,
             },
             "start": Object {
               "column": 1,
               "line": 4,
+              "offset": 160,
             },
           },
           "type": "text.plain",
@@ -199,10 +223,12 @@ Object {
             "end": Object {
               "column": 30,
               "line": 4,
+              "offset": 189,
             },
             "start": Object {
               "column": 23,
               "line": 4,
+              "offset": 182,
             },
           },
           "type": "text.strikeThrough",
@@ -214,10 +240,12 @@ Object {
             "end": Object {
               "column": 46,
               "line": 4,
+              "offset": 205,
             },
             "start": Object {
               "column": 30,
               "line": 4,
+              "offset": 189,
             },
           },
           "type": "text.plain",
@@ -229,10 +257,12 @@ Object {
         "end": Object {
           "column": 1,
           "line": 6,
+          "offset": 207,
         },
         "start": Object {
           "column": 1,
           "line": 3,
+          "offset": 40,
         },
       },
       "type": "paragraph",
@@ -251,10 +281,12 @@ Object {
             "end": Object {
               "column": 18,
               "line": 7,
+              "offset": 248,
             },
             "start": Object {
               "column": 1,
               "line": 7,
+              "offset": 231,
             },
           },
           "protocol": "file",
@@ -268,10 +300,12 @@ Object {
         "end": Object {
           "column": 19,
           "line": 7,
+          "offset": 249,
         },
         "start": Object {
           "column": 1,
           "line": 7,
+          "offset": 231,
         },
       },
       "type": "paragraph",
@@ -281,10 +315,12 @@ Object {
     "end": Object {
       "column": 19,
       "line": 7,
+      "offset": 249,
     },
     "start": Object {
       "column": 1,
       "line": 3,
+      "offset": 40,
     },
   },
   "properties": Object {},

--- a/packages/orga/src/position.ts
+++ b/packages/orga/src/position.ts
@@ -4,6 +4,10 @@ export const isEqual = (p1: Point, p2: Point) => {
   return p1.line === p2.line && p1.column === p2.column
 }
 
+export const isGreaterOrEqual = (p1: Point, p2: Point) => {
+  return isEqual(p1, p2) || before(p1)(p2);
+}
+
 const compare = (p1: Point, p2: Point): boolean => {
   if (p1.line > p2.line) return true
   if (p1.line === p2.line && p1.column > p2.column) return true
@@ -21,4 +25,3 @@ export const before = (p1: Point) => (p2: Point) => {
 export const isEmpty = (position: Position) => {
   return !position || isEqual(position.start, position.end)
 }
-

--- a/packages/orga/src/reader.ts
+++ b/packages/orga/src/reader.ts
@@ -12,6 +12,7 @@ export const read = (text: string) => {
     match,
     eof,
     eol: _eol,
+    distance,
   } = _read(text)
 
   let cursor = { line: 1, column: 1 }
@@ -60,10 +61,6 @@ export const read = (text: string) => {
 
   const EOF = () => {
     return isGreaterOrEqual(now(), eof());
-  }
-
-  const distance = ({ start, end }: Position) : number => {
-    return toIndex(end) - toIndex(start)
   }
 
   const jump = (point: Point) => {

--- a/packages/orga/src/reader.ts
+++ b/packages/orga/src/reader.ts
@@ -1,5 +1,6 @@
 import { read as _read } from 'text-kit'
 import { Point, Position } from 'unist'
+import { isGreaterOrEqual } from './position';
 
 export const read = (text: string) => {
 
@@ -9,7 +10,8 @@ export const read = (text: string) => {
     linePosition,
     toIndex,
     match,
-    location,
+    eof,
+    eol: _eol,
   } = _read(text)
 
   let cursor = { line: 1, column: 1 }
@@ -23,10 +25,6 @@ export const read = (text: string) => {
     return text.charAt(toIndex(pos) + offset)
   }
 
-  const endOfLine = (ln: number): Point => {
-    return location(toIndex(linePosition(ln).end))
-  }
-
   const now = () => cursor
 
   const eat = (param: 'char' | 'line' | 'whitespaces' | RegExp | number = 'char') => {
@@ -37,13 +35,13 @@ export const read = (text: string) => {
       const lp = linePosition(cursor.line)
       cursor = lp.end
     } else if (param === 'whitespaces') {
-      return eat(/^\s+/)
+      return eat(/^[ \t]+/)
     } else if (typeof param === 'number') {
       cursor = shift(start, param)
     } else {
-      const m = param.exec(substring({ start: cursor }))
+      const m = match(param, { start: cursor, end: eol() });
       if (m) {
-        cursor = location(toIndex(cursor) + m.index + m[0].length)
+        cursor = m.position.end;
       }
     }
 
@@ -58,10 +56,10 @@ export const read = (text: string) => {
     }
   }
 
-  const eol = () => endOfLine(cursor.line)
+  const eol = () => _eol(cursor.line);
 
   const EOF = () => {
-    return toIndex(now()) >= text.length - 1
+    return isGreaterOrEqual(now(), eof());
   }
 
   const distance = ({ start, end }: Position) : number => {
@@ -85,7 +83,6 @@ export const read = (text: string) => {
     jump,
     match: (pattern: RegExp, position: Position = { start: now(), end: eol() }) => match(pattern, position),
   }
-
   return reader
 }
 

--- a/packages/orga/src/reader.ts
+++ b/packages/orga/src/reader.ts
@@ -8,11 +8,11 @@ export const read = (text: string) => {
     shift,
     substring,
     linePosition,
-    toIndex,
     match,
     eof,
     eol: _eol,
     distance,
+    charAt,
   } = _read(text)
 
   let cursor = { line: 1, column: 1 }
@@ -20,10 +20,7 @@ export const read = (text: string) => {
   const isStartOfLine = () => cursor.column === 1
 
   const getChar = (p: number | Point = 0) => {
-    const { pos, offset } = typeof p === 'number' ?
-      { pos: cursor, offset: p } :
-      { pos: p, offset: 0 }
-    return text.charAt(toIndex(pos) + offset)
+    return typeof p === 'number' ? charAt(shift(cursor, p)) : charAt(p);
   }
 
   const now = () => cursor

--- a/packages/orga/src/tokenize/drawer.ts
+++ b/packages/orga/src/tokenize/drawer.ts
@@ -8,9 +8,10 @@ interface Props {
 export default ({ reader }: Props) : Token[] => {
   const { match, eat } = reader
 
-  const m = match(/^:(\w+):(?=\s*$)/)
+  const drawerReg = /^:(\w+):(?=\s*$)/;
+  const m = match(drawerReg);
   if (m) {
-    eat('line')
+    eat(drawerReg);
     const name = m.captures[1]
     if (name.toLowerCase() === 'end') {
       return [{

--- a/packages/orga/src/tokenize/headline.ts
+++ b/packages/orga/src/tokenize/headline.ts
@@ -80,6 +80,5 @@ export default ({ reader, todoKeywordSets }: Props) : Token[] => {
     })
     jump(tags.position.end)
   }
-  eat('line')
   return buffer
 }

--- a/packages/orga/src/tokenize/inline.ts
+++ b/packages/orga/src/tokenize/inline.ts
@@ -1,5 +1,5 @@
 import { Point } from 'unist'
-import { isEqual } from '../position'
+import { isGreaterOrEqual } from '../position'
 import { Reader } from '../reader'
 import { FootnoteReference, Link, PhrasingContent, StyledText, Token, Newline } from '../types'
 import uri from '../uri'
@@ -118,7 +118,7 @@ export const tokenize = ({ reader, start, end }: Props, { ignoring }: { ignoring
   }
 
   const cleanup = () => {
-    if (isEqual(cursor, now())) return
+    if (isGreaterOrEqual(cursor, now())) return
     const position = { start: { ...cursor }, end: { ...now() } }
     const value = substring(position)
     _tokens.push({
@@ -129,17 +129,20 @@ export const tokenize = ({ reader, start, end }: Props, { ignoring }: { ignoring
   }
 
   const tokNewline = (): Newline => {
-    const m = match(/^\n/)
-    if (!m) return undefined
-    return {
-      type: 'newline',
-      position: m.position,
+    const save = { ...now() };
+    const newline = eat('char');
+    jump(save);
+    if (newline.value === '\n') {
+      return {
+        type: 'newline',
+        position: newline.position,
+      };
     }
   }
 
   const tok = () => {
-    if (isEqual(now(), end)) {
-      return
+    if (isGreaterOrEqual(now(), end)) {
+      return;
     }
     const char = getChar()
 

--- a/packages/orga/src/tokenize/list.ts
+++ b/packages/orga/src/tokenize/list.ts
@@ -50,7 +50,5 @@ export default ({ reader }: Props) : Token[] => {
 
   tokens = tokens.concat(tokenizeInline({ reader }))
 
-  eat('line')
-
   return tokens
 }

--- a/packages/text-kit/jest.config.ts
+++ b/packages/text-kit/jest.config.ts
@@ -1,0 +1,7 @@
+export default {
+  rootDir: './',
+  preset: 'ts-jest',
+  testMatch: [
+    '**/__tests__/**/*.spec.ts',
+  ],
+}

--- a/packages/text-kit/package.json
+++ b/packages/text-kit/package.json
@@ -26,5 +26,9 @@
   },
   "bugs": {
     "url": "https://github.com/orgapp/orgajs/issues"
+  },
+  "devDependencies": {
+    "@types/unist": "^2.0.5",
+    "typescript": "^4.3.5"
   }
 }

--- a/packages/text-kit/package.json
+++ b/packages/text-kit/package.json
@@ -22,13 +22,15 @@
     "build": "yarn clean && yarn compile",
     "clean": "del ./dist/* && rm -rf tsconfig.tsbuildinfo",
     "compile": "tsc -b",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "test": "jest"
   },
   "bugs": {
     "url": "https://github.com/orgapp/orgajs/issues"
   },
   "devDependencies": {
     "@types/unist": "^2.0.5",
+    "jest": "^27.0.6",
     "typescript": "^4.3.5"
   }
 }

--- a/packages/text-kit/package.json
+++ b/packages/text-kit/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/orgapp/orgajs/issues"
   },
   "devDependencies": {
-    "@types/unist": "^2.0.5",
+    "@types/unist": "^2.0.0",
     "jest": "^27.0.6",
     "typescript": "^4.3.5"
   }

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -86,6 +86,12 @@ describe("substring", () => {
     testSubstring("single line", "test", { start: point(1, 1) }, "test");
     testSubstring("multiple lines", "test1\ntest2\ntest3", { start: point(2, 1) }, "test2");
   });
+
+  describe("substring from bof to eof is full text", () => {
+    for (const text of ["", "test", "test\n", "test1\ntest2", "test1\ntest2\n"]) {
+      testSubstring(`with text "${text}"`, text, r => ({ start: r.bof(), end: r.eof() }), text);
+    }
+  });
 });
 
 describe("linePosition", () => {
@@ -301,6 +307,22 @@ describe("eof", () => {
   describe("multiple lines", () => {
     testEof("no newline", "test1\ntest2\ntest3", point(3, 6, 17));
     testEof("newline", "test1\ntest2\ntest3\n", point(3, 7, 18));
+  });
+});
+
+describe("bof", () => {
+  const testBof = testReaderFn("bof");
+
+  testBof("empty document", "", point(1, 1, 0));
+
+  describe("single line", () => {
+    testBof("no newline", "test", point(1, 1, 0));
+    testBof("newline", "test\n", point(1, 1, 0));
+  });
+
+  describe("multiple lines", () => {
+    testBof("no newline", "test1\ntest2\ntest3", point(1, 1, 0));
+    testBof("newline", "test1\ntest2\ntest3\n", point(1, 1, 0));
   });
 });
 

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -1,9 +1,14 @@
-import { Point } from 'unist';
+import { Point, Position } from 'unist';
 import read from '../read';
 
 const point = (line: number, column: number): Point => ({ line, column });
 
 type Reader = ReturnType<typeof read>;
+
+const pos = ([startLine, startColumn]: [number, number], [endLine, endColumn]: [number, number]): Position => ({
+  start: point(startLine, startColumn),
+  end: point(endLine, endColumn),
+});
 
 const testReader = (testName: string, text: string, op: (r: Reader) => void) => {
   return it(testName, () => {
@@ -22,6 +27,21 @@ describe("numberOfLines", () => {
   testNumberOfLines("with some newlines", "test1\ntest2\n", 2);
   testNumberOfLines("starts with newline", "\ntest", 2);
   testNumberOfLines("ends with newline", "test\n", 1);
+});
+
+describe("linePosition", () => {
+  const testLinePosition = (testName: string, text: string, line: number, expected: ReturnType<Reader['linePosition']>) => {
+    return testReader(testName, text, r => expect(r.linePosition(line)).toEqual(expected));
+  };
+
+  describe("out-of-bounds lines", () => {
+    testLinePosition("line < 1", "test", 0, undefined);
+    testLinePosition("line > number of lines", "test", 2, undefined);
+  });
+
+  testLinePosition("only line", "test", 1, pos([1, 1], [1, 4]));
+  testLinePosition("line with newline", "test\n", 1, pos([1, 1], [1, 5]));
+  testLinePosition("middle line", "test\ntest\ntest", 2, pos([2, 1], [2, 5]));
 });
 
 describe("location", () => {

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -185,6 +185,28 @@ describe("shift", () => {
   });
 });
 
+describe("eol", () => {
+  const testEol = (testName: string, text: string, ln: number, expected: ReturnType<TextKit['eol']> | ((r: TextKit) => ReturnType<TextKit['eol']>)) => {
+    return testReader(testName, text, r => expect(r.eol(ln)).toEqual(typeof expected === 'function' ? expected(r) : expected));
+  };
+
+  describe("out-of-bounds", () => {
+    testEol("empty document", "", 1, undefined);
+    testEol("line before start of document", "test", -1, undefined);
+    testEol("line after end of document", "test", 2, undefined);
+  });
+
+  describe("single line", () => {
+    testEol("no newline", "test", 1, r => r.eof());
+    testEol("newline", "test\n", 1, point(1, 5));
+  });
+
+  describe("multiple lines", () => {
+    testEol("no newline", "test1\ntest2\ntest3", 3, r => r.eof());
+    testEol("newline", "test1\ntest2\ntest3", 2, point(2, 6));
+  });
+});
+
 describe("eof", () => {
   const testEof = (testName: string, text: string, expected: ReturnType<TextKit['eof']>) => {
     return testReader(testName, text, r => expect(r.eof()).toEqual(expected));

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -185,6 +185,34 @@ describe("shift", () => {
   });
 });
 
+describe("lastNonEOL", () => {
+  const testLastNonEOL = (testName: string, text: string, ln: number, expected: ReturnType<TextKit['lastNonEOL']>) => {
+    return testReader(testName, text, r => expect(r.lastNonEOL(ln)).toEqual(expected));
+  };
+
+  describe("out-of-bounds", () => {
+    testLastNonEOL("line before start of document", "test", -1, undefined);
+    testLastNonEOL("line after end of document", "test", 2, undefined);
+  });
+
+  describe("single line", () => {
+    testLastNonEOL("no newline", "test", 1, point(1, 4));
+    testLastNonEOL("newline", "test\n", 1, point(1, 4));
+  });
+
+  describe("multiple lines", () => {
+    testLastNonEOL("no newline", "test1\ntest2\ntest3", 3, point(3, 5));
+    testLastNonEOL("newline", "test1\ntest2\ntest3", 2, point(2, 5));
+  });
+
+  describe("empty line", () => {
+    testLastNonEOL("empty document", "", 1, undefined);
+    testLastNonEOL("single line", "\n", 1, undefined);
+    testLastNonEOL("multiple lines", "foo\n\nbar", 2, undefined);
+    testLastNonEOL("picking non-empty line", "foo\n\nbar", 3, point(3, 3));
+  });
+});
+
 describe("eol", () => {
   const testEol = (testName: string, text: string, ln: number, expected: ReturnType<TextKit['eol']> | ((r: TextKit) => ReturnType<TextKit['eol']>)) => {
     return testReader(testName, text, r => expect(r.eol(ln)).toEqual(typeof expected === 'function' ? expected(r) : expected));

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -94,6 +94,15 @@ describe("substring", () => {
   });
 });
 
+describe("charAt", () => {
+  const testCharAt = testReaderFn("charAt");
+
+  testCharAt("empty text", "", r => r.bof(), undefined);
+  testCharAt("newline", "test\ntest", r => r.eol(1), "\n");
+  testCharAt("middle of line", "test", point(1, 2), "e");
+  testCharAt("eof", "test", r => r.eof(), undefined);
+});
+
 describe("linePosition", () => {
   const testLinePosition = testReaderFn('linePosition');
 

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -11,7 +11,7 @@ describe("numberOfLines", () => {
     return testReader(testName, text, r => expect(r.numberOfLines).toEqual(expected));
   };
 
-  testNumberOfLines("with empty string", "", 1);
+  testNumberOfLines("with empty string", "", 0);
   testNumberOfLines("just a newline", "\n", 1);
   testNumberOfLines("with one newline", "test\n", 1);
   testNumberOfLines("with some newlines", "test1\ntest2\n", 2);

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -108,6 +108,7 @@ describe("location", () => {
     testLocation("empty document", "", 0, point(1, 1, 0));
     testLocation("index at EOF", "test", 4, point(1, 5, 4));
     testLocation("index higher than EOF", "test", 5, point(1, 5, 4));
+    testLocation("index higher than EOF, multiline", "test1\ntest2", 12, point(2, 6, 11));
     testLocation("negative index", "test", -1, point(1, 1, 0));
   });
 

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -1,0 +1,17 @@
+import read from '../read';
+
+const testReader = (testName: string, text: string, op: (r: ReturnType<typeof read>) => void) => {
+  return it(testName, () => {
+    op(read(text));
+  });
+};
+
+describe("numberOfLines", () => {
+  const testNumberOfLines = (testName: string, text: string, expected: number) => {
+    return testReader(testName, text, r => expect(r.numberOfLines).toEqual(expected));
+  };
+
+  testNumberOfLines("with empty string", "", 1);
+  testNumberOfLines("with one newline", "test\n", 1);
+  testNumberOfLines("with some newlines", "test1\ntest2\n", 2);
+});

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -50,6 +50,8 @@ describe("numberOfLines", () => {
   testNumberOfLines("with some newlines", "test1\ntest2\n", 2);
   testNumberOfLines("starts with newline", "\ntest", 2);
   testNumberOfLines("ends with newline", "test\n", 1);
+  testNumberOfLines("ends with carriage return", "test\r", 1);
+  testNumberOfLines("split with carriage return", "test\rtest", 2);
 });
 
 describe("substring", () => {
@@ -223,6 +225,8 @@ describe("lastNonEOL", () => {
   describe("single line", () => {
     testLastNonEOL("no newline", "test", 1, point(1, 4, 3));
     testLastNonEOL("newline", "test\n", 1, point(1, 4, 3));
+    testLastNonEOL("newline (carriage return)", "test\r", 1, point(1, 4, 3));
+    testLastNonEOL("newline (carriage return, newline)", "test\r\n", 1, point(1, 4, 3));
   });
 
   describe("multiple lines", () => {
@@ -250,6 +254,8 @@ describe("eol", () => {
   describe("single line", () => {
     testEol("no newline", "test", 1, r => r.eof());
     testEol("newline", "test\n", 1, point(1, 5, 4));
+    testEol("newline (carriage return)", "test\r", 1, point(1, 5, 4));
+    testEol("newline (carriage return, newline)", "test\r\n", 1, point(1, 5, 4));
   });
 
   describe("multiple lines", () => {
@@ -266,6 +272,7 @@ describe("eof", () => {
   describe("single line", () => {
     testEof("no newline", "test", point(1, 5, 4));
     testEof("newline", "test\n", point(1, 6, 5));
+    testEof("newline (carriage return)", "test\r", point(1, 6, 5));
   });
 
   describe("multiple lines", () => {

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -165,8 +165,8 @@ describe("match", () => {
 });
 
 describe("toIndex", () => {
-  const testToIndex = (testName: string, text: string, [line, column]: [number, number], expectedIndex: number) => {
-    return testReaderFn('toIndex')(testName, text, { line, column }, expectedIndex);
+  const testToIndex = (testName: string, text: string, [line, column, offset]: [number, number] | [number, number, number], expectedIndex: number) => {
+    return testReaderFn('toIndex')(testName, text, { line, column, offset }, expectedIndex);
   };
 
   describe("index out of bounds", () => {
@@ -180,6 +180,7 @@ describe("toIndex", () => {
       testToIndex("line too high", "test", [2, 1], 4);
       testToIndex("column too high", "test", [1, 7], 4);
       testToIndex("column too high ends with newline", "test\n", [1, 7], 5);
+      testToIndex("with offset", "test\n", [1, 7, 6], 5);
     });
     testToIndex("column too high multiple lines", "test\ntest", [1, 7], 4);
   });
@@ -190,6 +191,7 @@ describe("toIndex", () => {
     testToIndex("beginning of next line", "test\ntest", [2, 1], 5);
     testToIndex("middle of line", "tests", [1, 3], 2);
     testToIndex("middle of document", "tests\ntests\ntests", [2, 3], 8);
+    testToIndex("middle of document, with offset", "tests\ntests\ntests", [2, 3, 8], 8);
   });
 });
 

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -98,6 +98,12 @@ describe("location", () => {
     testLocation("next line", "test\ntest", 5, point(2, 1));
     testLocation("middle of text", "tests\ntests\ntests", 8, point(2, 3));
   });
+
+  describe("location inverse of toIndex", () => {
+    for (let i = 0; i <= 11; i++) {
+      testReader(`with i=${i}`, "test1\ntest2", r => expect(r.toIndex(r.location(i))).toEqual(i));
+    }
+  });
 });
 
 describe("match", () => {

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -1,4 +1,7 @@
+import { Point } from 'unist';
 import read from '../read';
+
+const point = (line: number, column: number): Point => ({ line, column });
 
 const testReader = (testName: string, text: string, op: (r: ReturnType<typeof read>) => void) => {
   return it(testName, () => {
@@ -17,6 +20,27 @@ describe("numberOfLines", () => {
   testNumberOfLines("with some newlines", "test1\ntest2\n", 2);
   testNumberOfLines("starts with newline", "\ntest", 2);
   testNumberOfLines("ends with newline", "test\n", 1);
+});
+
+describe("location", () => {
+  const testLocation = (testName: string, text: string, loc: number, expectedPoint: Point) => {
+    return testReader(testName, text, r => expect(r.location(loc)).toEqual(expectedPoint));
+  };
+
+  describe("location out of range", () => {
+    testLocation("empty document", "", 0, point(1, 1));
+    testLocation("index too high", "test", 4, point(1, 4));
+    testLocation("negative index", "test", -1, point(1, 1));
+  });
+
+  describe("location in bounds", () => {
+    testLocation("beginning of line", "test", 0, point(1, 1));
+    testLocation("end of line", "test", 3, point(1, 4));
+    testLocation("beginning of document", "test\ntest", 0, point(1, 1));
+    testLocation("end of document", "test\ntest", 8, point(2, 4));
+    testLocation("next line", "test\ntest", 5, point(2, 1));
+    testLocation("middle of text", "tests\ntests\ntests", 8, point(2, 3));
+  });
 });
 
 describe("toIndex", () => {

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -18,3 +18,30 @@ describe("numberOfLines", () => {
   testNumberOfLines("starts with newline", "\ntest", 2);
   testNumberOfLines("ends with newline", "test\n", 1);
 });
+
+describe("toIndex", () => {
+  const testToIndex = (testName: string, text: string, [line, column]: [number, number], expectedIndex: number) => {
+    return testReader(testName, text, r => expect(r.toIndex({ line, column })).toEqual(expectedIndex));
+  };
+
+  describe("index out of bounds", () => {
+    testToIndex("empty document", "", [1, 1], 0);
+    testToIndex("negative line", "test", [-1, 1], 0);
+    testToIndex("negative column", "test", [1, -1], 0);
+    testToIndex("negative column next line", "test\ntest", [2, -1], 5);
+    testToIndex("line too low", "test", [0, 1], 0);
+    testToIndex("line too high", "test", [2, 1], 3);
+    testToIndex("column too low", "test\ntest", [2, 0], 5);
+    testToIndex("column too high", "test", [1, 7], 3);
+    testToIndex("column too high ends with newline", "test\n", [1, 7], 4);
+    testToIndex("column too high multiple lines", "test\ntest", [1, 7], 4);
+  });
+
+  describe("index in bounds", () => {
+    testToIndex("beginning of line", "test", [1, 1], 0);
+    testToIndex("end of line", "test", [1, 4], 3);
+    testToIndex("beginning of next line", "test\ntest", [2, 1], 5);
+    testToIndex("middle of line", "tests", [1, 3], 2);
+    testToIndex("middle of document", "tests\ntests\ntests", [2, 3], 8);
+  });
+});

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -12,6 +12,9 @@ describe("numberOfLines", () => {
   };
 
   testNumberOfLines("with empty string", "", 1);
+  testNumberOfLines("just a newline", "\n", 1);
   testNumberOfLines("with one newline", "test\n", 1);
   testNumberOfLines("with some newlines", "test1\ntest2\n", 2);
+  testNumberOfLines("starts with newline", "\ntest", 2);
+  testNumberOfLines("ends with newline", "test\n", 1);
 });

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -1,16 +1,14 @@
 import { Point, Position } from 'unist';
-import read from '../read';
+import read, { TextKit } from '../read';
 
 const point = (line: number, column: number): Point => ({ line, column });
-
-type Reader = ReturnType<typeof read>;
 
 const pos = ([startLine, startColumn]: [number, number], [endLine, endColumn]: [number, number]): Position => ({
   start: point(startLine, startColumn),
   end: point(endLine, endColumn),
 });
 
-const testReader = (testName: string, text: string, op: (r: Reader) => void) => {
+const testReader = (testName: string, text: string, op: (r: TextKit) => void) => {
   return it(testName, () => {
     op(read(text));
   });
@@ -30,7 +28,7 @@ describe("numberOfLines", () => {
 });
 
 describe("substring", () => {
-  const testSubstring = (testName: string, text: string, testArg: Parameters<Reader['substring']>[number], expected: ReturnType<Reader['substring']>) => {
+  const testSubstring = (testName: string, text: string, testArg: Parameters<TextKit['substring']>[number], expected: ReturnType<TextKit['substring']>) => {
     return testReader(testName, text, r => expect(r.substring(testArg)).toEqual(expected));
   };
 
@@ -62,7 +60,7 @@ describe("substring", () => {
 });
 
 describe("linePosition", () => {
-  const testLinePosition = (testName: string, text: string, line: number, expected: ReturnType<Reader['linePosition']>) => {
+  const testLinePosition = (testName: string, text: string, line: number, expected: ReturnType<TextKit['linePosition']>) => {
     return testReader(testName, text, r => expect(r.linePosition(line)).toEqual(expected));
   };
 
@@ -98,7 +96,7 @@ describe("location", () => {
 });
 
 describe("match", () => {
-  const testMatch = (testName: string, text: string, testArgs: Parameters<Reader['match']>, expected: [Position, string[]] | undefined) => {
+  const testMatch = (testName: string, text: string, testArgs: Parameters<TextKit['match']>, expected: [Position, string[]] | undefined) => {
     return testReader(testName, text, r => expect(r.match(...testArgs)).toEqual(expected && { position: expected[0], captures: expected[1] }));
   };
 
@@ -155,7 +153,7 @@ describe("toIndex", () => {
 });
 
 describe("shift", () => {
-  const testShift = (testName: string, text: string, testArgs: Parameters<Reader['shift']>, expected: ReturnType<Reader['shift']>) => {
+  const testShift = (testName: string, text: string, testArgs: Parameters<TextKit['shift']>, expected: ReturnType<TextKit['shift']>) => {
     return testReader(testName, text, r => expect(r.shift(...testArgs)).toEqual(expected));
   };
 

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -3,7 +3,9 @@ import read from '../read';
 
 const point = (line: number, column: number): Point => ({ line, column });
 
-const testReader = (testName: string, text: string, op: (r: ReturnType<typeof read>) => void) => {
+type Reader = ReturnType<typeof read>;
+
+const testReader = (testName: string, text: string, op: (r: Reader) => void) => {
   return it(testName, () => {
     op(read(text));
   });
@@ -67,5 +69,23 @@ describe("toIndex", () => {
     testToIndex("beginning of next line", "test\ntest", [2, 1], 5);
     testToIndex("middle of line", "tests", [1, 3], 2);
     testToIndex("middle of document", "tests\ntests\ntests", [2, 3], 8);
+  });
+});
+
+describe("shift", () => {
+  const testShift = (testName: string, text: string, testArgs: Parameters<Reader['shift']>, expected: ReturnType<Reader['shift']>) => {
+    return testReader(testName, text, r => expect(r.shift(...testArgs)).toEqual(expected));
+  };
+
+  describe("out-of-bounds shifts", () => {
+    testShift("shifting beyond end of document", "test", [point(1, 1), 6], point(1, 4));
+    testShift("shifting before start of document", "test", [point(1, 1), -1], point(1, 1));
+  });
+
+  describe("in-bounds shifts", () => {
+    testShift("shift to start of next line", "test\ntest", [point(1, 4), 2], point(2, 1));
+    testShift("shift to start of next line (on newline)", "test\ntest", [point(1, 5), 1], point(2, 1));
+    testShift("shift to end of previous newline", "test\ntest", [point(2, 1), -1], point(1, 5));
+    testShift("shift to end of previous line", "test\ntest", [point(2, 1), -2], point(1, 4));
   });
 });

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -29,6 +29,38 @@ describe("numberOfLines", () => {
   testNumberOfLines("ends with newline", "test\n", 1);
 });
 
+describe("substring", () => {
+  const testSubstring = (testName: string, text: string, testArg: Parameters<Reader['substring']>[number], expected: ReturnType<Reader['substring']>) => {
+    return testReader(testName, text, r => expect(r.substring(testArg)).toEqual(expected));
+  };
+
+  describe("out-of-bounds", () => {
+    testSubstring("start line before beginning of document, end after", "test", pos([-1, 1], [2, 1]), "test");
+    testSubstring("start line in document, end after", "test", pos([1, 1], [2, 1]), "test");
+    testSubstring("start line before beginning of document, end within", "test", pos([-1, 1], [1, 2]), "te");
+    testSubstring("end is before start", "test", pos([1, 4], [1, 1]), "");
+  });
+
+  testSubstring("within line", "tests", pos([1, 2], [1, 4]), "est");
+  testSubstring("over multiple lines", "tests\ntests\ntests", pos([1, 3], [3, 3]), "sts\ntests\ntes");
+
+  describe("end is EOL", () => {
+    testSubstring("with one line", "test", { start: point(1, 1), end: 'EOL' }, "test");
+    testSubstring("with multiple lines", "test1\ntest2\ntest3", { start: point(2, 1), end: 'EOL' }, "test2\n");
+  });
+
+  describe("end is EOF", () => {
+    testSubstring("with one line", "test", { start: point(1, 1), end: 'EOF' }, "test");
+    testSubstring("with multiple lines", "test1\ntest2\ntest3", { start: point(2, 1), end: 'EOF' }, "test2\ntest3");
+    testSubstring("with multiple lines and ending newline", "test1\ntest2\ntest3\n", { start: point(2, 1), end: 'EOF' }, "test2\ntest3\n");
+  });
+
+  describe("with only start specified (default is EOL)", () => {
+    testSubstring("single line", "test", { start: point(1, 1) }, "test");
+    testSubstring("multiple lines", "test1\ntest2\ntest3", { start: point(2, 1) }, "test2\n");
+  });
+});
+
 describe("linePosition", () => {
   const testLinePosition = (testName: string, text: string, line: number, expected: ReturnType<Reader['linePosition']>) => {
     return testReader(testName, text, r => expect(r.linePosition(line)).toEqual(expected));

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -73,9 +73,9 @@ describe("linePosition", () => {
     testLinePosition("line > number of lines", "test", 2, undefined);
   });
 
-  testLinePosition("only line", "test", 1, pos([1, 1], [1, 4]));
-  testLinePosition("line with newline", "test\n", 1, pos([1, 1], [1, 5]));
-  testLinePosition("middle line", "test\ntest\ntest", 2, pos([2, 1], [2, 5]));
+  testLinePosition("only line", "test", 1, pos([1, 1], [1, 5]));
+  testLinePosition("line with newline", "test\n", 1, pos([1, 1], [1, 6]));
+  testLinePosition("middle line", "test\ntest\ntest", 2, pos([2, 1], [3, 1]));
 });
 
 describe("location", () => {

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -136,9 +136,9 @@ describe("location", () => {
     testLocation("middle of text", "tests\ntests\ntests", 8, point(2, 3, 8));
   });
 
-  describe("location inverse of toIndex", () => {
+  describe("location inverse of index", () => {
     for (let i = 0; i <= 11; i++) {
-      testReader(`with i=${i}`, "test1\ntest2", r => expect(r.toIndex(r.location(i))).toEqual(i));
+      testReader(`with i=${i}`, "test1\ntest2", r => expect(r.location(i).offset).toEqual(i));
     }
   });
 });
@@ -180,37 +180,6 @@ describe("match", () => {
   testMatch("if end is before start this is undefined", "Test\nTest", [/Test/, pos([2, 1], [1, 1])], undefined);
   testMatch("if end is before start this is undefined (even with empty RegExp)", "Test\nTest", [new RegExp(""), pos([2, 1], [1, 1])], undefined);
   testMatch("a newline", "\n", [/^\n/, pos([1, 1], [1, 1])], undefined);
-});
-
-describe("toIndex", () => {
-  const testToIndex = (testName: string, text: string, [line, column, offset]: [number, number] | [number, number, number], expectedIndex: number) => {
-    return testReaderFn('toIndex')(testName, text, { line, column, offset }, expectedIndex);
-  };
-
-  describe("index out of bounds", () => {
-    testToIndex("empty document", "", [1, 1], 0);
-    testToIndex("negative line", "test", [-1, 1], 0);
-    testToIndex("negative column", "test", [1, -1], 0);
-    testToIndex("negative column next line", "test\ntest", [2, -1], 5);
-    testToIndex("line too low", "test", [0, 1], 0);
-    testToIndex("column too low", "test\ntest", [2, 0], 5);
-    describe("EOF", () => {
-      testToIndex("line too high", "test", [2, 1], 4);
-      testToIndex("column too high", "test", [1, 7], 4);
-      testToIndex("column too high ends with newline", "test\n", [1, 7], 5);
-      testToIndex("with offset", "test\n", [1, 7, 6], 5);
-    });
-    testToIndex("column too high multiple lines", "test\ntest", [1, 7], 4);
-  });
-
-  describe("index in bounds", () => {
-    testToIndex("beginning of line", "test", [1, 1], 0);
-    testToIndex("end of line", "test", [1, 4], 3);
-    testToIndex("beginning of next line", "test\ntest", [2, 1], 5);
-    testToIndex("middle of line", "tests", [1, 3], 2);
-    testToIndex("middle of document", "tests\ntests\ntests", [2, 3], 8);
-    testToIndex("middle of document, with offset", "tests\ntests\ntests", [2, 3, 8], 8);
-  });
 });
 
 describe("shift", () => {

--- a/packages/text-kit/src/__tests__/read.spec.ts
+++ b/packages/text-kit/src/__tests__/read.spec.ts
@@ -243,6 +243,28 @@ describe("lastNonEOL", () => {
   });
 });
 
+describe("bol", () => {
+  const testBol = testReaderFn("bol");
+
+  describe("out-of-bounds", () => {
+    testBol("empty document", "", 1, undefined);
+    testBol("line before start of document", "test", -1, undefined);
+    testBol("line after end of document", "test", 2, undefined);
+  });
+
+  describe("single line", () => {
+    testBol("some text, no newline", "test", 1, point(1, 1, 0));
+    testBol("some text, newline", "test\n", 1, point(1, 1, 0));
+    testBol("just a newline", "\n", 1, point(1, 1, 0));
+  });
+
+  describe("multiple lines", () => {
+    testBol("some text, no newline", "test1\ntest2", 2, point(2, 1, 6));
+    testBol("some text, newline", "test1\ntest2", 2, point(2, 1, 6));
+    testBol("just a newline", "test1\n\n", 2, point(2, 1, 6));
+  });
+});
+
 describe("eol", () => {
   const testEol = testReaderFn("eol");
 

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -87,6 +87,13 @@ export interface TextKit {
 
   /** Return a {@link SourcePoint} representing the end of the text. */
   eof(): SourcePoint;
+
+  /**
+   * Return the distance (possibly negative) between two points in the
+   * source, i.e., the distance `n` such that `shift(range.start, n)`
+   * would be at `range.end`.
+   */
+  distance(range: Position): number;
 }
 
 export default (text: string): TextKit => {
@@ -219,6 +226,10 @@ export default (text: string): TextKit => {
     }
   }
 
+  const distance = (range: Position): number => {
+    return toIndex(range.end) - toIndex(range.start);
+  };
+
   return {
     get numberOfLines(): number {
       return lines.length
@@ -232,5 +243,6 @@ export default (text: string): TextKit => {
     lastNonEOL,
     eol,
     eof,
+    distance,
   }
 }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -64,6 +64,9 @@ export interface TextKit {
 
   /** Offset the given `point` by the provided `offset`. */
   shift: (point: Point, offset: number) => Point;
+
+  /** Return a {@link Point} representing the end of the text. */
+  eof(): Point;
 }
 
 export default (text: string): TextKit => {
@@ -78,10 +81,14 @@ export default (text: string): TextKit => {
     return (line < lines.length ? lines[line] : text.length) - lines[line - 1];
   }
 
-  const eof = (): Point => ({
-    line: lines.length + 1,
-    column: 1,
-  });
+  const eof = (): Point => {
+    const len = lengthOfLine(lines.length);
+    if (!len) return { line: 1, column: 1 };
+    return {
+      line: lines.length,
+      column: len + 1,
+    };
+  };
 
   const toIndex = (point: Point): number => {
     const index = toIndexOrEOF(point);
@@ -182,5 +189,6 @@ export default (text: string): TextKit => {
     match,
     toIndex,
     shift,
+    eof,
   }
 }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -6,6 +6,12 @@ export default (text: string) => {
   const lines: number[] = strLines.length > 0 ? [0] : []; // index of line starts
   strLines.slice(0, strLines.length - 1).forEach((l, i) => lines.push(lines[i] + l.length));
 
+  /** Return the length of the given line, if it exists. */
+  const lengthOfLine = (line: number): number | undefined => {
+    if (line < 1 || line > lines.length) return;
+    return (line < lines.length ? lines[line] : text.length) - lines[line - 1];
+  }
+
   /**
    * Return the best-fit index of a point in the text.
    *
@@ -23,7 +29,7 @@ export default (text: string) => {
     if (line > lines.length) return text.length - 1;
     const targetLineStartIndex = lines[line - 1];
     if (column < 1) return targetLineStartIndex;
-    const maxCol = line < lines.length ? lines[line] : text.length - targetLineStartIndex;
+    const maxCol = lengthOfLine(line)!;
     const index = targetLineStartIndex + Math.min(column, maxCol) - 1;
     return Math.min(index, text.length);
   }
@@ -85,15 +91,14 @@ export default (text: string) => {
     return location(toIndex(point) + offset)
   }
 
+  /** Return the span of the document covered by the given line, or `undefined` if the line doesn't exist. */
   const linePosition = (ln: number): Position | undefined => {
-    if (ln < 1 || ln > lines.length) return undefined
-    const nextLine = lines[ln]
-    const endIndex = nextLine ? nextLine - 1 : text.length
-    // console.log({ nextLine, endIndex, end: location(endIndex) })
+    const lineLength = lengthOfLine(ln);
+    if (!lineLength) return;
     return {
       start: { line: ln, column: 1 },
-      end: location(endIndex),
-    }
+      end: { line: ln, column: lineLength },
+    };
   }
 
   const substring = ({ start, end = 'EOL' }: {

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -80,6 +80,7 @@ export default (text: string) => {
     }
   }
 
+  /** Offset the given `point` by the provided `offset`. */
   const shift = (point: Point, offset: number): Point => {
     return location(toIndex(point) + offset)
   }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -105,10 +105,11 @@ export default (text: string): TextKit => {
   };
 
   const eol = (ln: number): Point | undefined => {
-    const pos = linePosition(ln);
-    if (!pos) return;
-    const end = pos.end;
-    return ((text.charAt(toIndex(end)).match(/$/mg) ?? []).length > 1) ? end : eof();
+    const len = lengthOfLine(ln);
+    if (!len) return;
+    const endIndex = lines[ln - 1] + len - 1;
+    const end = { line: ln, column: len };
+    return ((text.charAt(endIndex).match(/$/mg) ?? []).length > 1) ? end : eof();
   }
 
   const lastNonEOL = (ln: number): Point | undefined => {
@@ -181,11 +182,11 @@ export default (text: string): TextKit => {
   }
 
   const linePosition = (ln: number): Position | undefined => {
-    const lineLength = lengthOfLine(ln);
-    if (!lineLength) return;
+    const end = eol(ln);
+    if (!end) return;
     return {
       start: { line: ln, column: 1 },
-      end: { line: ln, column: lineLength },
+      end: shift(end, 1),
     };
   }
 

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -28,22 +28,33 @@ export default (text: string) => {
     return Math.min(index, text.length);
   }
 
-  const middle = (start: number, end: number) => {
-    return start + Math.floor((end - start) / 2)
+  /**
+   * Find the line on which the given `index` resides.
+   *
+   * Note the following exceptions:
+   *
+   * - if `index` is less than `0` then this is line `1`;
+   * - if `index` is greater than the maximum index then this is the last line
+   */
+  const findLine = (index: number): number => {
+    const l = lines.findIndex((_l, i) => i === lines.length - 1 ? true : index < lines[i + 1]);
+    return l === -1 ? 1 : l + 1;
   }
 
-  const findLine = (index: number, start: number, end: number): number => {
-    if (index < 0) return 1
-    if (index >= text.length) return lines.length
-    const mid = middle(start, end)
-    if (lines[mid - 1] > index) return findLine(index, start, mid)
-    if (lines[mid] <= index) return findLine(index, mid, end)
-    return mid
-  }
-
+  /**
+   * Return the {@link Point} for a given `index` in the text.
+   *
+   * Note the following exceptions:
+   *
+   * - if `index` is less than `0` then this is the starting point;
+   * - if `index` is larger than the greatest index in the text then this is the maximum point;
+   * - if the text is empty then this is the 1-1-point
+   */
   const location = (index: number): Point => {
-    const line = findLine(index, 1, lines.length + 1)
-    const column = Math.min(index, text.length) - toIndex({ line, column: 1 }) + 1
+    const line = findLine(index)
+    if (lines.length === 0) return { line: 1, column: 1 };
+    const lineStartIndex = lines[line - 1];
+    const column = toIndex({ line, column: index - lineStartIndex + 1 }) - lineStartIndex + 1;
     return {
       line,
       column,

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -10,10 +10,25 @@ export default (text: string) => {
     cursor = nl + 1
   } while (cursor > 0 && cursor < text.length)
 
+  /**
+   * Return the best-fit index of a point in the text.
+   *
+   * Specifically, if the point is invalid w.r.t. the text, then the
+   * following behaviours are observed:
+   *
+   * - if `line` is less than `1` then the index is `0`;
+   * - if `line` is greater than the number of lines, then the maximum index is returned;
+   * - if `column` is less than `1` then the start-of-line index is returned;
+   * - if `column` is greater than the length of the line, then the end-of-line index is returned;
+   * - if the text is empty, then the index is 0
+   */
   const toIndex = ({ line, column }: Point): number => {
     if (line < 1) return 0
-    if (line > lines.length) return text.length
-    const index = lines[line - 1] + column - 1
+    if (line > lines.length) return text.length - 1;
+    const targetLineStartIndex = lines[line - 1];
+    if (column < 1) return targetLineStartIndex;
+    const maxCol = line < lines.length ? lines[line] : text.length - targetLineStartIndex;
+    const index = targetLineStartIndex + Math.min(column, maxCol) - 1;
     return Math.max(0, Math.min(index, text.length))
   }
 

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -166,13 +166,11 @@ export default (text: string): TextKit => {
     if (!content) return undefined
     const match = pattern.exec(content)
     if (!match) return undefined
-    const offset = toIndex(position.start)
-    const captures = match.map(m => m)
     return {
-      captures,
+      captures: match.map(m => m),
       position: {
-        start: location(offset + match.index),
-        end: location(offset + match.index + match[0].length),
+        start: shift(position.start, match.index),
+        end: shift(position.start, match.index + match[0].length),
       }
     }
   }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -67,6 +67,12 @@ export default (text: string) => {
     }
   }
 
+  /**
+   * Match `pattern` against the region of text selected by `position`.
+   *
+   * If the match fails, returns `undefined`. If the match succeeds,
+   * returns the match array along with the span covered by the match.
+   */
   const match = (
     pattern: RegExp,
     position: Position,
@@ -81,7 +87,7 @@ export default (text: string) => {
       captures,
       position: {
         start: location(offset + match.index),
-        end: location(offset + match.index + match[0].length),
+        end: location(offset + match.index + match[0].length - 1),
       }
     }
   }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -65,6 +65,13 @@ export interface TextKit {
   /** Offset the given `point` by the provided `offset`. */
   shift: (point: Point, offset: number) => Point;
 
+  /**
+   * {@link Point} representing the newline character of the
+   * given `line`, or EOF. Returns `undefined` if the line does not
+   * exist.
+   */
+  eol(line: number): Point | undefined;
+
   /** Return a {@link Point} representing the end of the text. */
   eof(): Point;
 }
@@ -89,6 +96,13 @@ export default (text: string): TextKit => {
       column: len + 1,
     };
   };
+
+  const eol = (ln: number): Point | undefined => {
+    const pos = linePosition(ln);
+    if (!pos) return;
+    const end = pos.end;
+    return ((text.charAt(toIndex(end)).match(/$/mg) ?? []).length > 1) ? end : eof();
+  }
 
   const toIndex = (point: Point): number => {
     const index = toIndexOrEOF(point);
@@ -189,6 +203,7 @@ export default (text: string): TextKit => {
     match,
     toIndex,
     shift,
+    eol,
     eof,
   }
 }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -63,8 +63,8 @@ export default (text: string) => {
     return {
       captures,
       position: {
-        start: location(offset + match.index) as Point,
-        end: location(offset + match.index + match[0].length) as Point,
+        start: location(offset + match.index),
+        end: location(offset + match.index + match[0].length),
       }
     }
   }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -66,6 +66,13 @@ export interface TextKit {
   shift: (point: Point, offset: number) => Point;
 
   /**
+   * {@link Point} representing the last non-newline character of the
+   * given `line`. Returns `undefined` if the line does not
+   * exist or is empty.
+   */
+  lastNonEOL(line: number): Point | undefined;
+
+  /**
    * {@link Point} representing the newline character of the
    * given `line`, or EOF. Returns `undefined` if the line does not
    * exist.
@@ -102,6 +109,12 @@ export default (text: string): TextKit => {
     if (!pos) return;
     const end = pos.end;
     return ((text.charAt(toIndex(end)).match(/$/mg) ?? []).length > 1) ? end : eof();
+  }
+
+  const lastNonEOL = (ln: number): Point | undefined => {
+    const end = eol(ln);
+    if (!end || end.column === 1) return;
+    return shift(end, -1);
   }
 
   const toIndex = (point: Point): number => {
@@ -203,6 +216,7 @@ export default (text: string): TextKit => {
     match,
     toIndex,
     shift,
+    lastNonEOL,
     eol,
     eof,
   }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -32,9 +32,6 @@ export interface TextKitCore {
   /** Get the character at the given point, if it exists. */
   charAt(loc: Point): string | undefined;
 
-  /** Return the span of the document covered by the given line, or `undefined` if the line doesn't exist. */
-  linePosition: (ln: number) => SourcePosition | undefined;
-
   /**
    * Return the {@link SourcePoint} for a given `index` in the text.
    *
@@ -106,6 +103,9 @@ export interface TextKit extends TextKitCore {
    * exist or is empty.
    */
   lastNonEOL(line: number): SourcePoint | undefined;
+
+  /** Return the span of the document covered by the given line, or `undefined` if the line doesn't exist. */
+  linePosition: (ln: number) => SourcePosition | undefined;
 }
 
 export const core = (text: string): TextKitCore => {
@@ -201,15 +201,6 @@ export const core = (text: string): TextKitCore => {
     return location(toIndex(point) + offset)
   }
 
-  const linePosition = (ln: number): SourcePosition | undefined => {
-    const [start, end] = [bol(ln), eol(ln)];
-    if (!start || !end) return;
-    return {
-      start,
-      end: shift(end, 1),
-    };
-  }
-
   const charAt = (loc: Point): string | undefined => {
     const c = text.charAt(toIndex(loc));
     return c === "" ? undefined : c;
@@ -242,7 +233,6 @@ export const core = (text: string): TextKitCore => {
     },
     charAt,
     substring,
-    linePosition,
     location,
     shift,
     bol,
@@ -254,7 +244,7 @@ export const core = (text: string): TextKitCore => {
 }
 
 export const extra = (tk: TextKitCore): TextKit => {
-  const { eol, shift, substring } = tk;
+  const { bol, eol, shift, substring } = tk;
   const lastNonEOL = (ln: number): SourcePoint | undefined => {
     const end = eol(ln);
     if (!end || end.column === 1) return;
@@ -277,9 +267,19 @@ export const extra = (tk: TextKitCore): TextKit => {
     };
   };
 
+  const linePosition = (ln: number): SourcePosition | undefined => {
+    const [start, end] = [bol(ln), eol(ln)];
+    if (!start || !end) return;
+    return {
+      start,
+      end: shift(end, 1),
+    };
+  }
+
   return {
     ...tk,
     lastNonEOL,
+    linePosition,
     match,
   }
 }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -85,7 +85,14 @@ export interface TextKit {
    */
   eol(line: number): SourcePoint | undefined;
 
-  /** Return a {@link SourcePoint} representing the end of the text. */
+  /**
+   * Return a {@link SourcePoint} representing the end of the text.
+   *
+   * Note that this does not represent a point of a physical character
+   * in the file, but rather a virtual point (beyond the last
+   * character). This can be used to include the last character of the
+   * text in a range.
+   */
   eof(): SourcePoint;
 
   /**

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -2,13 +2,9 @@ import { Point, Position } from 'unist';
 
 export default (text: string) => {
 
-  let cursor = 0
-  const lines: number[] = [] // index of line starts
-  do {
-    lines.push(cursor)
-    const nl = text.indexOf('\n', cursor)
-    cursor = nl + 1
-  } while (cursor > 0 && cursor < text.length)
+  const strLines = text.split(/^/mg);
+  const lines: number[] = strLines.length > 0 ? [0] : []; // index of line starts
+  strLines.slice(0, strLines.length - 1).forEach((l, i) => lines.push(lines[i] + l.length));
 
   /**
    * Return the best-fit index of a point in the text.
@@ -23,13 +19,13 @@ export default (text: string) => {
    * - if the text is empty, then the index is 0
    */
   const toIndex = ({ line, column }: Point): number => {
-    if (line < 1) return 0
+    if (text.length === 0 || line < 1) return 0;
     if (line > lines.length) return text.length - 1;
     const targetLineStartIndex = lines[line - 1];
     if (column < 1) return targetLineStartIndex;
     const maxCol = line < lines.length ? lines[line] : text.length - targetLineStartIndex;
     const index = targetLineStartIndex + Math.min(column, maxCol) - 1;
-    return Math.max(0, Math.min(index, text.length))
+    return Math.min(index, text.length);
   }
 
   const middle = (start: number, end: number) => {

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -66,7 +66,7 @@ export interface TextKit {
    * - if `column` is greater than the length of the line, then the end-of-line index (or EOF) is returned;
    * - if the text is empty, then the index is 0
    */
-  toIndex: ({ line, column }: Point) => number;
+  toIndex: (point: Point) => number;
 
   /** Offset the given `point` by the provided `offset`. */
   shift: (point: Point, offset: number) => SourcePoint;
@@ -130,7 +130,12 @@ export default (text: string): TextKit => {
     return index === 'EOF' ? text.length : index;
   }
 
-  const toIndexOrEOF = ({ line, column }: Point): number | 'EOF' => {
+  /** Return an index that is guaranteed to represent a character in the source or EOF. */
+  const fixIndex = (i: number): number =>
+    i < 0 ? 0 : i >= text.length ? text.length : i;
+
+  const toIndexOrEOF = ({ line, column, offset }: Point): number | 'EOF' => {
+    if (offset !== undefined) return fixIndex(offset);
     if (text.length === 0 || line < 1) return 0;
     if (line > lines.length) return 'EOF';
     const targetLineStartIndex = lines[line - 1];

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -101,27 +101,28 @@ export default (text: string) => {
     };
   }
 
+  /**
+   * Retrieve the portion of the text covered by the given span (inclusive of ends).
+   *
+   * `end` may be a {@link Point}, or may be `EOL`, in which case it
+   * is the end of the `start` line (including any newline character),
+   * or `EOF`, in which case it is the end of the document.
+   *
+   * `end` is optional and defaults to `EOL`.
+   *
+   * Note that if `end` is before `start`, this is the empty string.
+   */
   const substring = ({ start, end = 'EOL' }: {
     start: Point,
     end?: Point | 'EOL' | 'EOF'
   }): string => {
 
-    let endIndex: number | undefined;
-    if (end === 'EOL') {
-      const lp = linePosition(start.line)
-      if (!lp) {
-        console.log({ start })
-      }
-      const lineEnd = linePosition(start.line)?.end;
-      if (lineEnd) {
-        endIndex = toIndex(lineEnd)
-      }
-    } else if (end === 'EOF') {
-      endIndex = text.length
-    } else {
-      endIndex = toIndex(end)
-    }
-    return text.substring(toIndex(start), endIndex)
+    const startIndex = toIndex(start);
+    const endIndex = end === 'EOF' ? text.length - 1
+      : end === 'EOL' ? toIndex({ ...start, column: Infinity })
+        : toIndex(end);
+    if (endIndex < startIndex) return "";
+    return text.substring(startIndex, endIndex + 1)
   }
 
   return {

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -25,11 +25,11 @@ export default (text: string) => {
     return Math.max(0, Math.min(index, text.length))
   }
 
-  const middle = (start, end) => {
+  const middle = (start: number, end: number) => {
     return start + Math.floor((end - start) / 2)
   }
 
-  const findLine = (index: number, start: number, end: number) => {
+  const findLine = (index: number, start: number, end: number): number => {
     if (index < 0) return 1
     if (index >= text.length) return lines.length
     const mid = middle(start, end)
@@ -70,7 +70,7 @@ export default (text: string) => {
     return location(toIndex(point) + offset)
   }
 
-  const linePosition = (ln: number): Position => {
+  const linePosition = (ln: number): Position | undefined => {
     if (ln < 1 || ln > lines.length) return undefined
     const nextLine = lines[ln]
     const endIndex = nextLine ? nextLine - 1 : text.length
@@ -85,13 +85,16 @@ export default (text: string) => {
     start: Point,
     end?: Point | 'EOL' | 'EOF' }): string => {
 
-    let endIndex: number
+    let endIndex: number | undefined;
     if (end === 'EOL') {
       const lp = linePosition(start.line)
       if (!lp) {
         console.log({ start })
       }
-      endIndex = toIndex(linePosition(start.line).end)
+      const lineEnd = linePosition(start.line)?.end;
+      if (lineEnd) {
+        endIndex = toIndex(lineEnd)
+      }
     } else if (end === 'EOF') {
       endIndex = text.length
     } else {

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -29,6 +29,9 @@ export interface TextKitCore {
     end?: Point | 'EOL' | 'EOF'
   }) => string;
 
+  /** Get the character at the given point, if it exists. */
+  charAt(loc: Point): string | undefined;
+
   /** Return the span of the document covered by the given line, or `undefined` if the line doesn't exist. */
   linePosition: (ln: number) => SourcePosition | undefined;
 
@@ -221,6 +224,11 @@ export const core = (text: string): TextKitCore => {
     };
   }
 
+  const charAt = (loc: Point): string | undefined => {
+    const c = text.charAt(toIndex(loc));
+    return c === "" ? undefined : c;
+  };
+
   const substring = ({ start, end = 'EOL' }: {
     start: Point,
     end?: Point | 'EOL' | 'EOF'
@@ -246,6 +254,7 @@ export const core = (text: string): TextKitCore => {
     get numberOfLines(): number {
       return lines.length
     },
+    charAt,
     substring,
     linePosition,
     location,

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -1,12 +1,4 @@
-interface Point {
-  line: number;
-  column: number;
-}
-
-interface Position {
-  start: Point;
-  end: Point;
-}
+import { Point, Position } from 'unist';
 
 export default (text: string) => {
 

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -46,20 +46,6 @@ export interface TextKitCore {
    */
   location: (index: number) => SourcePoint;
 
-  /**
-   * Return the best-fit index of a point in the text.
-   *
-   * Specifically, if the point is invalid w.r.t. the text, then the
-   * following behaviours are observed:
-   *
-   * - if `line` is less than `1` then the index is `0`;
-   * - if `line` is greater than the number of lines, then the size of the text is returned;
-   * - if `column` is less than `1` then the start-of-line index is returned;
-   * - if `column` is greater than the length of the line, then the end-of-line index (or EOF) is returned;
-   * - if the text is empty, then the index is 0
-   */
-  toIndex: (point: Point) => number;
-
   /** Offset the given `point` by the provided `offset`. */
   shift: (point: Point, offset: number) => SourcePoint;
 
@@ -258,7 +244,6 @@ export const core = (text: string): TextKitCore => {
     substring,
     linePosition,
     location,
-    toIndex,
     shift,
     bol,
     eol,

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -75,6 +75,13 @@ export interface TextKitCore {
   eol(line: number): SourcePoint | undefined;
 
   /**
+   * Return a {@link SourcePoint} representing the start of the text.
+   *
+   * This is either the first character of the text, or {@link eof}.
+   */
+  bof(): SourcePoint;
+
+  /**
    * Return a {@link SourcePoint} representing the end of the text.
    *
    * Note that this does not represent a point of a physical character
@@ -128,6 +135,8 @@ export const core = (text: string): TextKitCore => {
     if (!lineExists(line)) return;
     return (line < lines.length ? lines[line] : text.length) - lines[line - 1];
   }
+
+  const bof = (): SourcePoint => ({ line: 1, column: 1, offset: 0 });
 
   const eof = (): SourcePoint => {
     const len = lengthOfLine(lines.length);
@@ -244,6 +253,7 @@ export const core = (text: string): TextKitCore => {
     shift,
     bol,
     eol,
+    bof,
     eof,
     distance,
   }

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -50,7 +50,7 @@ export default (text: string) => {
   const match = (
     pattern: RegExp,
     position: Position,
-  ) : { position: Position, captures: string[] } | undefined => {
+  ): { position: Position, captures: string[] } | undefined => {
     const content = substring(position)
     if (!content) return undefined
     const match = pattern.exec(content)
@@ -66,7 +66,7 @@ export default (text: string) => {
     }
   }
 
-  const shift = (point: Point, offset: number) : Point => {
+  const shift = (point: Point, offset: number): Point => {
     return location(toIndex(point) + offset)
   }
 
@@ -83,7 +83,8 @@ export default (text: string) => {
 
   const substring = ({ start, end = 'EOL' }: {
     start: Point,
-    end?: Point | 'EOL' | 'EOF' }): string => {
+    end?: Point | 'EOL' | 'EOF'
+  }): string => {
 
     let endIndex: number | undefined;
     if (end === 'EOL') {

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -1,7 +1,10 @@
-import { Point, Position } from 'unist';
+import { Point as UnistPoint, Position } from 'unist';
 
-/** Like {@link Point}, but with a known source index. */
-export type SourcePoint = Required<Point>;
+/** Like {@link UnistPoint}, but with no offset. */
+export type Point = Omit<UnistPoint, 'offset'>;
+
+/** Like {@link UnistPoint}, but with a known source index. */
+export type SourcePoint = Required<UnistPoint>;
 
 /** Like {@link Position}, but with known indices. */
 export type SourcePosition = Position & { start: SourcePoint, end: SourcePoint };

--- a/packages/text-kit/src/read.ts
+++ b/packages/text-kit/src/read.ts
@@ -1,10 +1,7 @@
-import { Point as UnistPoint, Position } from 'unist';
+import { Point, Position } from 'unist';
 
-/** Like {@link UnistPoint}, but with no offset. */
-export type Point = Omit<UnistPoint, 'offset'>;
-
-/** Like {@link UnistPoint}, but with a known source index. */
-export type SourcePoint = Required<UnistPoint>;
+/** Like {@link Point}, but with a known source index. */
+export type SourcePoint = Required<Point>;
 
 /** Like {@link Position}, but with known indices. */
 export type SourcePosition = Position & { start: SourcePoint, end: SourcePoint };

--- a/packages/text-kit/tsconfig.json
+++ b/packages/text-kit/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "noImplicitAny": true,
+    "strictNullChecks": true,
     "rootDir": "./src",
     "outDir": "./dist"
   },


### PR DESCRIPTION
Adds tests, documentation, and stricter type-checking to `text-kit`.

@xiaoxinghu this is basically good for review. The main thing I wanted to ask you about was how you want `match` and `substring` to work. Previously, the end "point" was considered exclusively - that is, a range starting and ending at the same point would be empty, whereas now it is a single character. This makes more sense when you think about larger ranges - previously, the end of the range would always be cut out, but now if you e.g., wanted the range from point `1` to point `2`, this would be the first and second characters, not just the first.

I kinda want to add a `Region` type which allows a bit more flexibility in terms of specifying where to match, but TypeScript doesn't seem to like this at the moment (the narrowing isn't good enough).


I think existing packages are expecting `match` to behave the old way, so maybe we should just stick with that...