### PR TITLE
Solves #183 for `packages/orga`

### DIFF
--- a/packages/orga/src/parse/block.ts
+++ b/packages/orga/src/parse/block.ts
@@ -1,23 +1,20 @@
 import { Action, Handler } from '.'
 import { BlockBegin, BlockEnd } from '../types'
 
-const block: Action = (
-  begin: BlockBegin,
-  { save, push, enter, lexer, attributes }
-): Handler => {
-  save()
+const block: Action = (begin: BlockBegin, context): Handler => {
+  context.save()
   const contentStart = begin.position.end
   const blockName = begin.name.toLowerCase()
 
-  const block = enter({
+  const block = context.enter({
     type: 'block',
     name: begin.name,
     params: begin.params,
     value: '',
-    attributes: { ...attributes },
+    attributes: { ...context.attributes },
     children: [],
   })
-  push(lexer.eat())
+  context.push(context.lexer.eat())
 
   /*
    * find the indentation of the block and apply it to
@@ -56,34 +53,33 @@ const block: Action = (
     rules: [
       {
         test: 'block.end',
-        action: (token: BlockEnd, { exit, push, lexer }) => {
-          const { eat } = lexer
+        action: (token: BlockEnd, context) => {
           if (token.name.toLowerCase() !== blockName) return 'next'
           block.value = align(
-            lexer.substring({
+            context.lexer.substring({
               start: contentStart,
               end: token.position.start,
             })
           )
-          push(eat())
-          eat('newline')
-          exit('block')
+          context.push(context.lexer.eat())
+          context.lexer.eat('newline')
+          context.exit('block')
           return 'break'
         },
       },
       {
         test: ['stars', 'EOF'],
-        action: (_, { restore, lexer }) => {
-          restore()
-          lexer.modify((t) => ({
+        action: (_, context) => {
+          context.restore()
+          context.lexer.modify((t) => ({
             type: 'text',
-            value: lexer.substring(t.position),
+            value: context.lexer.substring(t.position),
             position: t.position,
           }))
           return 'break'
         },
       },
-      { test: /./, action: (_, { push, lexer }) => push(lexer.eat()) },
+      { test: /./, action: (_, context) => context.push(context.lexer.eat()) },
     ],
   }
 }

--- a/packages/orga/tsconfig.json
+++ b/packages/orga/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.esm.json",
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist"

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -11,5 +11,11 @@
     "allowJs": true,
     "lib": ["ES2020"]
   },
-  "exclude": ["node_modules", "**/*.spec.ts", "**/__tests__/**", "tests/**"]
+  "exclude": [
+    "node_modules",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/__tests__/**",
+    "tests/**"
+  ]
 }


### PR DESCRIPTION
Here we do two things:
- We use `jest` with `tsconfig.esm.json`
- We fix the test that are failing

---
_Side notes:_ My worries is that this pattern might be spread across the codebase, this is just what I stumble on.
Destructuring keeps the code concises, I wonder if there would be another way. 