### PR TITLE
Fix imports for react

### DIFF
--- a/.changeset/eighty-buckets-live.md
+++ b/.changeset/eighty-buckets-live.md
@@ -1,0 +1,5 @@
+---
+'@orgajs/react': patch
+---
+
+Fix package

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,7 @@
   "name": "@orgajs/react",
   "version": "4.1.0",
   "license": "MIT",
-  "main": "index.js",
+  "main": "lib/index.js",
   "type": "module",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
Fix because I kept getting the following errors:
```
Failed to compile.

./components/posts/first.org
Module not found: Can't resolve 'next-orga-import-source-file' in '$DIR/next-app/components/posts'
Import trace for requested module:
./components/posts/first.org


> Build failed because of webpack errors
error Command failed with exit code 1.
```
with @orgajs/react@4.1.0


